### PR TITLE
Update to go1.25.4 to fix vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yottta/ddns
 
-go 1.25.0
+go 1.25.4
 
 require (
 	github.com/cloudflare/cloudflare-go/v6 v6.1.0


### PR DESCRIPTION
This change resolves several go vulnerabilities.

Resolves https://github.com/yottta/ddns/issues/10
Resolves https://github.com/yottta/ddns/issues/11
Resolves https://github.com/yottta/ddns/issues/12
Resolves https://github.com/yottta/ddns/issues/13
Resolves https://github.com/yottta/ddns/issues/14
Resolves https://github.com/yottta/ddns/issues/15
Resolves https://github.com/yottta/ddns/issues/16